### PR TITLE
make jquery local

### DIFF
--- a/templates/error/maintenance.html
+++ b/templates/error/maintenance.html
@@ -7,7 +7,7 @@
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" crossorigin="anonymous">
         <link href="/assets/css/style.css" rel="stylesheet">
 
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js" crossorigin="anonymous"></script>
+        <script src="/assets/js/jquery.min.js"></script>
         <script src="/assets/js/bootstrap.bundle.min.js"></script>
 
         <link href="/static/favicon.png" rel="icon">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -8,7 +8,7 @@
         <link href="/assets/css/github-markdown.css" rel="stylesheet">
         <link href="/assets/css/style.css" rel="stylesheet">
 
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js" crossorigin="anonymous"></script>
+        <script src="/assets/js/jquery.min.js"></script>
         <script src="/assets/js/bootstrap.bundle.min.js"></script>
 
         <link href="/static/favicon.png" rel="icon">


### PR DESCRIPTION
improves security; with most browsers ending cache partitioning there is no longer any meaningful benefit from using a cdn