### PR TITLE
Dark mode

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -176,3 +176,7 @@ a {
 .dark .page-item.active .page-link {
     background-color: #0d6efd!important;
 }
+
+.dark-toggle:checked {
+    background-color: #2f2f2f;
+}

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -145,11 +145,34 @@ a {
     color: #fff;
 }
 
-.dark.card {
+.dark .card {
     border: 1px solid rgba(255, 255, 255, .125);
+    background-color: #2f2f2f;
 }
 
-.dark.form-control:focus {
+.dark .form-control:focus {
     background-color: #2f2f2f;
     color: #fff;
+}
+
+.dark .form-control {
+    background-color: #2f2f2f;
+    color: #fff;
+}
+
+.dark tr {
+    background-color: #2f2f2f;
+    color: #fff;
+}
+
+.dark tr:hover {
+    color: #fff!important;
+}
+
+.dark .page-link {
+    background-color: #2f2f2f!important;
+}
+
+.dark .page-item.active .page-link {
+    background-color: #0d6efd!important;
 }

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -6,7 +6,7 @@
 }
 
 .see-more-wrapper {
-    background-color: #ffffff;
+    background-color: inherit;
     position: absolute;
     bottom: 0;
     padding: 4px 0;
@@ -136,4 +136,20 @@ a {
 
 .svg-green {
     filter: invert(57%) sepia(58%) saturate(3606%) hue-rotate(83deg) brightness(118%) contrast(125%);
+}
+
+/****************** DARK MODE ********************************/
+.dark {
+    background: #2f2f2f;
+    background-color: #2f2f2f;
+    color: #fff;
+}
+
+.dark.card {
+    border: 1px solid rgba(255, 255, 255, .125);
+}
+
+.dark.form-control:focus {
+    background-color: #2f2f2f;
+    color: #fff;
 }

--- a/src/assets/js/darkMode.js
+++ b/src/assets/js/darkMode.js
@@ -1,29 +1,42 @@
-let darkMode = false;
+function setCookie(name, val, exp) {
+    var d = new Date();
+    d.setTime(d.getTime() + (exp*24*60*60*1000)); // expiry in days
+    var expires = "expires=" + d.toUTCString();
+    document.cookie = name + "=" + val + ";" + expires + ";path=/";
+}
+
+function getCookie(name) {
+    name += "=";
+    var decodedCookie = decodeURIComponent(document.cookie);
+    var ca = decodedCookie.split(';');
+    for(var i = 0; i < ca.length; i++) {
+        var c = ca[i];
+        while (c.charAt(0) == ' ') {
+            c = c.substring(1);
+        }
+        if (c.indexOf(name) == 0) {
+            return c.substring(name.length, c.length);
+        }
+    }
+    return "";
+}
+
+if (getCookie("darkMode") == 1) enableDark();
 
 function toggleDark() {
-    if (darkMode) disableDark();
-    else enableDark();
-    darkMode = !darkMode;
+    if (getCookie("darkMode") == 1) {
+        disableDark();
+        setCookie("darkMode", 0, 7);
+    } else {
+        enableDark();
+        setCookie("darkMode", 1, 7);
+    }
 }
 
 
 function enableDark() {
     document.body.classList.add("dark");
-    $("input").addClass("dark");
-    $("textarea").addClass("dark");
-    $(".form-control").addClass("dark");
-    $(".set-dark").addClass("dark");
-    $(".card").addClass("dark");
-    $("table").addClass("dark");
-    $(".btn-primary").removeClass("dark");
 }
-
 function disableDark() {
     document.body.classList.remove("dark");
-    $("input").removeClass("dark");
-    $("textarea").removeClass("dark");
-    $(".form-control").removeClass("dark");
-    $(".set-dark").removeClass("dark");
-    $("table").removeClass("dark");
-    $(".card").removeClass("dark");
 }

--- a/src/assets/js/darkMode.js
+++ b/src/assets/js/darkMode.js
@@ -1,0 +1,29 @@
+let darkMode = false;
+
+function toggleDark() {
+    if (darkMode) disableDark();
+    else enableDark();
+    darkMode = !darkMode;
+}
+
+
+function enableDark() {
+    document.body.classList.add("dark");
+    $("input").addClass("dark");
+    $("textarea").addClass("dark");
+    $(".form-control").addClass("dark");
+    $(".set-dark").addClass("dark");
+    $(".card").addClass("dark");
+    $("table").addClass("dark");
+    $(".btn-primary").removeClass("dark");
+}
+
+function disableDark() {
+    document.body.classList.remove("dark");
+    $("input").removeClass("dark");
+    $("textarea").removeClass("dark");
+    $(".form-control").removeClass("dark");
+    $(".set-dark").removeClass("dark");
+    $("table").removeClass("dark");
+    $(".card").removeClass("dark");
+}

--- a/src/assets/js/darkMode.js
+++ b/src/assets/js/darkMode.js
@@ -21,7 +21,10 @@ function getCookie(name) {
     return "";
 }
 
-if (getCookie("darkMode") == 1) enableDark();
+if (getCookie("darkMode") == 1) {
+    enableDark();
+    document.querySelector(".dark-toggle").setAttribute("checked", "");
+}
 
 function toggleDark() {
     if (getCookie("darkMode") == 1) {

--- a/src/templates/error/maintenance.html
+++ b/src/templates/error/maintenance.html
@@ -27,5 +27,6 @@
             <hr>
             <p class="text-center">© 2020, {{ CLUB_NAME }}. Source code available <a href="https://github.com/jdabtieu/CTFOJ">here</a>.</p>
         </footer>
+        <script src="/assets/js/darkMode.js"></script>
     </body>
 </html>

--- a/src/templates/layout.html
+++ b/src/templates/layout.html
@@ -31,12 +31,14 @@
                             {% endif %}
                         </ul>
                         <ul class="navbar-nav">
+                            <li class="nav-link" onclick="toggleDark()">Toggle Dark</li>
                             <li class="nav-link white">Welcome, {{ session.username }}</li>
                             <li><a class="nav-link" href="/settings">Settings</a></li>
                             <li><a class="nav-link" href="/logout">Log Out</a></li>
                         </ul>
                     {% else %}
                         <ul class="navbar-nav ms-auto">
+                            <li class="nav-link" onclick="toggleDark()">Toggle Dark</li>
                             <li><a class="nav-link" href="/register">Register</a></li>
                             <li><a class="nav-link" href="/login">Log In</a></li>
                         </ul>
@@ -65,6 +67,7 @@
         
         <!-- TODO: Remove jQuery -->
         <script src="/assets/js/jquery.min.js"></script>
+        <script src="/assets/js/darkMode.js"></script>
         <script src="/assets/js/showdown.min.js"></script>
         <script src="/assets/js/purify.min.js"></script>
         <script src="/assets/js/jquery.twbsPagination.min.js"></script>

--- a/src/templates/layout.html
+++ b/src/templates/layout.html
@@ -65,9 +65,9 @@
             <p class="text-center">© 2020, {{ CLUB_NAME }}. <a href="https://github.com/jdabtieu/CTFOJ">Source Code</a> - <a href="/terms">Terms of Service</a> - <a href="/privacy">Privacy Policy</a></p>
         </footer>
         
+        <script src="/assets/js/darkMode.js"></script>
         <!-- TODO: Remove jQuery -->
         <script src="/assets/js/jquery.min.js"></script>
-        <script src="/assets/js/darkMode.js"></script>
         <script src="/assets/js/showdown.min.js"></script>
         <script src="/assets/js/purify.min.js"></script>
         <script src="/assets/js/jquery.twbsPagination.min.js"></script>

--- a/src/templates/layout.html
+++ b/src/templates/layout.html
@@ -31,14 +31,18 @@
                             {% endif %}
                         </ul>
                         <ul class="navbar-nav">
-                            <li class="nav-link" onclick="toggleDark()">Toggle Dark</li>
+                            <div class="form-check form-switch nav-link">
+                                <input class="form-check-input dark-toggle" onclick="toggleDark()" type="checkbox">
+                            </div>
                             <li class="nav-link white">Welcome, {{ session.username }}</li>
                             <li><a class="nav-link" href="/settings">Settings</a></li>
                             <li><a class="nav-link" href="/logout">Log Out</a></li>
                         </ul>
                     {% else %}
                         <ul class="navbar-nav ms-auto">
-                            <li class="nav-link" onclick="toggleDark()">Toggle Dark</li>
+                            <div class="form-check form-switch nav-link">
+                                <input class="form-check-input dark-toggle" onclick="toggleDark()" type="checkbox">
+                            </div>
                             <li><a class="nav-link" href="/register">Register</a></li>
                             <li><a class="nav-link" href="/login">Log In</a></li>
                         </ul>


### PR DESCRIPTION
Adds support for dark mode

Users can toggle it using a switch on the navbar
This will set a cookie for 7 days to remember their selection

It can also be manually called through the javascript console using `toggleDark()`, but why would anyone do that?

Closes #76

Anyways, should be good as it only affects layout (which I've already tested extensively) and no backend code