### PR TITLE
Fix typos

### DIFF
--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -50,7 +50,7 @@ if [[ $? != 0 ]]; then
     echo "**STOPPING**"
     exit 1
 fi
-echo "Precheck complate!"
+echo "Precheck complete!"
 . bin/activate || . Scripts/activate
 cd src
 echo "Installing dependencies..."

--- a/src/application.py
+++ b/src/application.py
@@ -109,7 +109,7 @@ def check_for_maintenance():
     maintenance_mode = bool(os.path.exists('maintenance_mode'))
     if maintenance_mode:
         if request.path[:5] == '/api/':
-            return make_response(("The site is currrently undergoing maintenance", 503))
+            return make_response(("The site is currently undergoing maintenance", 503))
 
         # Prevent Internal Server error if session only contains CSRF token
         if not session or 'admin' not in session:
@@ -770,7 +770,7 @@ def contest_notify(contest_id):
     logger.info((f"User #{session['user_id']} ({session['username']}) sent a "
                  f"notification email to participants of contest {contest_id}"),
                 extra={"section": "problem"})
-    flash('Participants sucessfully notified', 'success')
+    flash('Participants successfully notified', 'success')
     return redirect("/contest/" + contest_id)
 
 
@@ -1711,7 +1711,7 @@ def reset_password():
     db.execute("UPDATE users SET password=:p WHERE id=:id",
                p=generate_password_hash(password), id=user_id)
 
-    flash(f"Password for {user[0]['username']} resetted! Their new password is {password}",  # noqa
+    flash(f"Password for {user[0]['username']} was reset! Their new password is {password}",  # noqa
           "success")
     logger.info((f"User #{user_id} ({user[0]['username']})'s password reset by "
                  f"user #{session['user_id']} ({session['username']})"),

--- a/src/templates/error/500.html
+++ b/src/templates/error/500.html
@@ -4,6 +4,6 @@
 
 {% block main %}
 <h1>Internal Server Error</h1>
-An unexpected error occured and the server was unable to process your request.
+An unexpected error occurred and the server was unable to process your request.
 <a href="/">Back to Home</a>
 {% endblock %}


### PR DESCRIPTION
Found typos with:
```
pip install codespell
codespell
```

`resetted` is not a word