### PR TITLE
Add X-Fowarded-For middleware

### DIFF
--- a/src/application.py
+++ b/src/application.py
@@ -18,6 +18,7 @@ from werkzeug.exceptions import HTTPException, InternalServerError, default_exce
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from helpers import *  # noqa
+from middlewares import ProxyFix
 
 app = Flask(__name__)
 
@@ -28,6 +29,11 @@ except Exception as e:
     app.config.from_object('default_settings')
 app.jinja_env.globals['CLUB_NAME'] = app.config['CLUB_NAME']
 app.jinja_env.globals['USE_CAPTCHA'] = app.config['USE_CAPTCHA']
+
+# Add middlewares
+if app.config["USE_X_FORWARDED_FOR"]:
+    app.wsgi_app = ProxyFix(app.wsgi_app)
+
 
 # Configure logging
 LOG_HANDLER = logging.FileHandler(app.config['LOGGING_FILE_LOCATION'])

--- a/src/default_settings.py
+++ b/src/default_settings.py
@@ -37,6 +37,16 @@ HCAPTCHA_SITE = "site_key"
 
 # Configure other settings here
 """
+If you are running CTFOJ under a proxy (e.g. PythonAnywhere, Nginx, or Apache), users'
+IP addresses should come from the X-Forwarded-For header. This is done automatically on
+PythonAnywhere, but with Nginx, you should add this line to your server block:
+        proxy_set_header        X-Forwarded-For  $proxy_add_x_forwarded_for;
+Apache/other proxies should also set the header to the real user IP.
+If you enable this option, you MUST set the X-Forwarded-For setting.
+"""
+USE_X_FORWARDED_FOR = False
+
+"""
 CLUB_NAME should store the name of your CTF club. It will be displayed in the navbar,
 footer, and page title.
 """

--- a/src/middlewares.py
+++ b/src/middlewares.py
@@ -1,0 +1,60 @@
+"""
+X-Forwarded-For Proxy Fix
+=========================
+This module provides a middleware that adjusts the WSGI environ based on
+``X-Forwarded-`` headers that proxies in front of an application may
+set.
+When an application is running behind a proxy server, WSGI may see the
+request as coming from that server rather than the real client. Proxies
+set various headers to track where the request actually came from.
+This middleware should only be used if the application is actually
+behind such a proxy, and should be configured with the number of proxies
+that are chained in front of it. Not all proxies set all the headers.
+Since incoming headers can be faked, you must set how many proxies are
+setting each header so the middleware knows what to trust.
+.. autoclass:: ProxyFix
+:copyright: 2007 Pallets
+:license: BSD-3-Clause
+
+https://github.com/pallets/werkzeug/blob/8fe91b792fb7ff46af6372a7ffbe3d5a4f58598a/src/werkzeug/middleware/proxy_fix.py
+"""
+import typing as t
+
+from werkzeug.http import parse_list_header
+
+
+class ProxyFix:
+    """
+    Adjust the WSGI environ based on ``X-Forwarded-For`` that proxies in
+    front of the application may set.
+    """
+    def __init__(self, app) -> None:
+        self.app = app
+
+    def _get_real_value(self, trusted: int, value: t.Optional[str]) -> t.Optional[str]:
+        """Get the real value from a list header based on the configured
+        number of trusted proxies.
+        :param trusted: Number of values to trust in the header.
+        :param value: Comma separated list header value to parse.
+        :return: The real value, or ``None`` if there are fewer values
+            than the number of trusted proxies.
+        """
+        if not (trusted and value):
+            return None
+        values = parse_list_header(value)
+        if len(values) >= trusted:
+            return values[-trusted]
+        return None
+
+    def __call__(self, environ, start_response) -> t.Iterable[bytes]:
+        """Modify the WSGI environ based on the various ``Forwarded``
+        headers before calling the wrapped application. Store the
+        original environ values in ``werkzeug.proxy_fix.orig_{key}``.
+        """
+
+        x_for = self._get_real_value(1, environ.get("HTTP_X_FORWARDED_FOR"))
+        if x_for:
+            environ["REMOTE_ADDR"] = x_for
+        else:
+            raise KeyError("No X-Forwarded-For header found. Make sure to set it in your proxy.")
+        return self.app(environ, start_response)


### PR DESCRIPTION
Set request.remote_addr to the trusted value in X-Forwarded-For if running CTFOJ under a proxy

For Pythonanywhere, Nginx, and other proxies